### PR TITLE
Add missing/useful functionality to new BoneMenu

### DIFF
--- a/BoneLib/BoneLib/BoneMenu/DefaultMenu.cs
+++ b/BoneLib/BoneLib/BoneMenu/DefaultMenu.cs
@@ -26,15 +26,9 @@ namespace BoneLib.BoneMenu
         {
             Page mainPage = Page.Root.CreatePage("BoneLib", Color.white);
 
-            Page.Root.CreatePageLink(mainPage);
-
             Page ammoPage = mainPage.CreatePage("Ammo Settings", Color.yellow);
             Page itemSpawningPage = mainPage.CreatePage("Item Spawning", Color.white);
             Page funStuffPage = mainPage.CreatePage("Fun Stuff", Color.white);
-
-            mainPage.CreatePageLink(ammoPage);
-            mainPage.CreatePageLink(itemSpawningPage);
-            mainPage.CreatePageLink(funStuffPage);
 
             ammoPage.CreateFunction("Add Light Ammo", Color.white, () => AmmoInventory.AddCartridge(LightAmmo, lightAmmoValue));
             ammoPage.CreateFunction("Add Medium Ammo", Color.white, () => AmmoInventory.AddCartridge(MediumAmmo, mediumAmmoValue));

--- a/BoneLib/BoneLib/BoneMenu/Elements/BoolElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/BoolElement.cs
@@ -16,7 +16,18 @@ namespace BoneLib.BoneMenu
             _value = _startValue;
         }
 
-        public bool Value => _value;
+        public bool Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value;
+                OnElementChanged?.Invoke();
+            }
+        }
 
         private bool _startValue;
         private bool _value;

--- a/BoneLib/BoneLib/BoneMenu/Elements/Element.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/Element.cs
@@ -13,12 +13,47 @@ namespace BoneLib.BoneMenu
             _elementType = "Base";
         }
         
-        public string ElementName => _elementName;
-        public Color ElementColor => _elementColor;
+        public string ElementName
+        {
+            get
+            {
+                return _elementName;
+            }
+            set
+            {
+                _elementName = value;
+                OnElementChanged?.Invoke();
+            }
+        }
+        public Color ElementColor 
+        {
+            get
+            {
+                return _elementColor;
+            }
+            set
+            {
+                _elementColor = value;
+                OnElementChanged?.Invoke();
+            }
+        }
         public string ElementType => _elementType;
-        public string ElementTooltip => _elementTooltip;
+        public string ElementTooltip 
+        {
+            get
+            {
+                return _elementTooltip;
+            }
+            set
+            {
+                _elementTooltip = value;
+                OnElementChanged?.Invoke();
+            }
+        }
         public bool HasTooltip => !string.IsNullOrEmpty(_elementTooltip);
         public ElementProperties Properties { get; private set; }
+
+        public Action OnElementChanged;
 
         protected string _elementName;
         protected Color _elementColor;

--- a/BoneLib/BoneLib/BoneMenu/Elements/EnumElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/EnumElement.cs
@@ -11,7 +11,18 @@ namespace BoneLib.BoneMenu
             _value = _internalValues.GetValue(0) as Enum;
         }
 
-        public Enum Value => _value;
+        public Enum Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value;
+                OnElementChanged?.Invoke();
+            }
+        }
 
         private Enum _value;
         private Array _internalValues;

--- a/BoneLib/BoneLib/BoneMenu/Elements/FloatElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/FloatElement.cs
@@ -20,7 +20,18 @@ namespace BoneLib.BoneMenu
 
         public static Action<Element, float> OnValueChanged;
 
-        public float Value => _value;
+        public float Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value;
+                OnElementChanged?.Invoke();
+            }
+        }
 
         private float _value;
         private float _minValue;

--- a/BoneLib/BoneLib/BoneMenu/Elements/FunctionElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/FunctionElement.cs
@@ -26,6 +26,7 @@ namespace BoneLib.BoneMenu
         public void SetLogo(Texture2D logo)
         {
             _logo = logo;
+            OnElementChanged?.Invoke();
         }
     }
 }

--- a/BoneLib/BoneLib/BoneMenu/Elements/FunctionElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/FunctionElement.cs
@@ -13,7 +13,18 @@ namespace BoneLib.BoneMenu
             _callback = callback;
         }
 
-        public Texture2D Logo => _logo;
+        public Texture2D Logo 
+        {
+            get
+            {
+                return _logo;
+            }
+            set
+            {
+                _logo = value;
+                OnElementChanged?.Invoke();
+            }
+        }
 
         private Texture2D _logo;
         private Action _callback;
@@ -21,12 +32,6 @@ namespace BoneLib.BoneMenu
         public override void OnElementSelected()
         {
             _callback?.Invoke();
-        }
-
-        public void SetLogo(Texture2D logo)
-        {
-            _logo = logo;
-            OnElementChanged?.Invoke();
         }
     }
 }

--- a/BoneLib/BoneLib/BoneMenu/Elements/IntElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/IntElement.cs
@@ -20,7 +20,18 @@ namespace BoneLib.BoneMenu
 
         public static Action<Element, int> OnValueChanged;
 
-        public int Value => _value;
+        public int Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value;
+                OnElementChanged?.Invoke();
+            }
+        }
 
         private int _value;
         private int _minValue;

--- a/BoneLib/BoneLib/BoneMenu/Elements/PageLinkElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/PageLinkElement.cs
@@ -1,0 +1,45 @@
+using System;
+using UnityEngine;
+
+namespace BoneLib.BoneMenu
+{
+    [Serializable]
+    public class PageLinkElement : FunctionElement
+    {
+        public PageLinkElement(string name, Color color, Action callback) : base(name, color, callback)
+        {
+        }
+
+        private Page _linkedPage;
+
+        public Page LinkedPage => _linkedPage;
+
+        public void AssignPage(Page page)
+        {
+            _linkedPage = page;
+            Menu.OnPageUpdated += OnPageUpdated;
+        }
+
+        public override void OnElementRemoved()
+        {
+            base.OnElementRemoved();
+
+            if (_linkedPage != null)
+            {
+                Menu.OnPageUpdated -= OnPageUpdated;
+                _linkedPage = null;
+            }
+        }
+
+        private void OnPageUpdated(Page page)
+        {
+            if (page != _linkedPage)
+            {
+                return;
+            }
+
+            ElementName = page.Name;
+            ElementColor = page.Color;
+        }
+    }
+}

--- a/BoneLib/BoneLib/BoneMenu/Elements/PageLinkElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/PageLinkElement.cs
@@ -17,6 +17,7 @@ namespace BoneLib.BoneMenu
         public void AssignPage(Page page)
         {
             _linkedPage = page;
+
             Menu.OnPageUpdated += OnPageUpdated;
         }
 
@@ -27,6 +28,7 @@ namespace BoneLib.BoneMenu
             if (_linkedPage != null)
             {
                 Menu.OnPageUpdated -= OnPageUpdated;
+
                 _linkedPage = null;
             }
         }

--- a/BoneLib/BoneLib/BoneMenu/Elements/StringElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/StringElement.cs
@@ -14,7 +14,18 @@ namespace BoneLib.BoneMenu
             _callback = callback;
         }
         
-        public string Value => _value;
+        public string Value
+        {
+            get
+            {
+                return _value;
+            }
+            set
+            {
+                _value = value;
+                OnElementChanged?.Invoke();
+            }
+        }
 
         private string _startValue;
         private string _value;
@@ -24,11 +35,6 @@ namespace BoneLib.BoneMenu
         {
             base.OnElementSelected();
             _callback?.Invoke(_value);
-        }
-
-        public void SetText(string text)
-        {
-            _value = text;
         }
     }
 }

--- a/BoneLib/BoneLib/BoneMenu/Menu.cs
+++ b/BoneLib/BoneLib/BoneMenu/Menu.cs
@@ -85,6 +85,14 @@ namespace BoneLib.BoneMenu
                     return;
                 }
             }
+
+            OnPageRemoved?.Invoke(page);
+            PageDirectory?.Remove(page.Name);
+
+            if (page.Parent.ChildPages.ContainsKey(page.Name))
+            {
+                page.Parent.ChildPages.Remove(page.Name);
+            }
         }
 
         public static void OpenPage(string pageName)

--- a/BoneLib/BoneLib/BoneMenu/Page.cs
+++ b/BoneLib/BoneLib/BoneMenu/Page.cs
@@ -68,8 +68,30 @@ namespace BoneLib.BoneMenu
 
         public Page Parent;
 
-        public string Name => _name;
-        public Color Color => _color;
+        public string Name
+        {
+            get
+            {
+                return _name;
+            }
+            set
+            {
+                _name = value;
+                Menu.OnPageOpened?.Invoke(this);
+            }
+        }
+        public Color Color 
+        {
+            get
+            {
+                return _color;
+            }
+            set
+            {
+                _color = value;
+                Menu.OnPageOpened?.Invoke(this);
+            }
+        }
 
         public Texture2D Logo { get; set; }
         public Texture2D Background { get; set; }

--- a/BoneLib/BoneLib/BoneMenu/Page.cs
+++ b/BoneLib/BoneLib/BoneMenu/Page.cs
@@ -355,8 +355,9 @@ namespace BoneLib.BoneMenu
         /// <param name="name"></param>
         /// <param name="color"></param>
         /// <param name="maxElements"></param>
+        /// <param name="createLink"></param>
         /// <returns></returns>
-        public Page CreatePage(string name, Color color, int maxElements = 0)
+        public Page CreatePage(string name, Color color, int maxElements = 0, bool createLink = true)
         {
             if (ChildPages.ContainsKey(name))
             {
@@ -366,6 +367,12 @@ namespace BoneLib.BoneMenu
             Page page = new Page(parent: this, name, color, maxElements);
             ChildPages.Add(name, page);
             Menu.OnPageCreated?.Invoke(this);
+
+            if (createLink)
+            {
+                CreatePageLink(page);
+            }
+
             return page;
         }
 

--- a/BoneLib/BoneLib/BoneMenu/Page.cs
+++ b/BoneLib/BoneLib/BoneMenu/Page.cs
@@ -426,7 +426,12 @@ namespace BoneLib.BoneMenu
         /// <returns></returns>
         public FunctionElement CreatePageLink(Page page)
         {
-            return CreateFunction(page.Name, page.Color, () => { Menu.OpenPage(page); });
+            var element = new PageLinkElement(page.Name, page.Color, () => { Menu.OpenPage(page); });
+            Add(element);
+
+            element.AssignPage(page);
+
+            return element;
         }
 
         private SubPage FindAvailable()

--- a/BoneLib/BoneLib/BoneMenu/Page.cs
+++ b/BoneLib/BoneLib/BoneMenu/Page.cs
@@ -163,6 +163,11 @@ namespace BoneLib.BoneMenu
         /// <param name="element">The element to remove.</param>
         public void Remove(Element element)
         {
+            if (element is PageLinkElement link)
+            {
+                Menu.DestroyPage(link.LinkedPage);
+            }
+
             _elements.Remove(element);
             _numElements--;
             Menu.OnPageUpdated?.Invoke(this);
@@ -180,6 +185,11 @@ namespace BoneLib.BoneMenu
 
             foreach (Element queryElement in query)
             {
+                if (queryElement is PageLinkElement link)
+                {
+                    Menu.DestroyPage(link.LinkedPage);
+                }
+
                 _elements.Remove(queryElement);
             }
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
@@ -32,6 +32,14 @@ namespace BoneLib.BoneMenu.UI
             element.OnElementChanged += Draw;
         }
 
+        private void OnDestroy()
+        {
+            if (_backingElement != null)
+            {
+                _backingElement.OnElementChanged -= Draw;
+            }
+        }
+
         public override void Draw()
         {
             base.Draw();

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
@@ -29,6 +29,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(BoolElement element)
         {
             _backingElement = element;
+            element.OnElementChanged += Draw;
         }
 
         public override void Draw()

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
@@ -37,6 +37,8 @@ namespace BoneLib.BoneMenu.UI
             base.Draw();
 
             _nameText.text = _backingElement.ElementName;
+            _nameText.color = _backingElement.ElementColor;
+
             _valueText.text = _backingElement.Value ? "Enabled" : "Disabled";
         }
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIBoolElement.cs
@@ -29,14 +29,14 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(BoolElement element)
         {
             _backingElement = element;
-            element.OnElementChanged += Draw;
+            element.OnElementChanged += Refresh;
         }
 
         private void OnDestroy()
         {
             if (_backingElement != null)
             {
-                _backingElement.OnElementChanged -= Draw;
+                _backingElement.OnElementChanged -= Refresh;
             }
         }
 
@@ -44,6 +44,11 @@ namespace BoneLib.BoneMenu.UI
         {
             base.Draw();
 
+            Refresh();
+        }
+
+        public void Refresh()
+        {
             _nameText.text = _backingElement.ElementName;
             _nameText.color = _backingElement.ElementColor;
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
@@ -32,6 +32,14 @@ namespace BoneLib.BoneMenu.UI
             element.OnElementChanged += Draw;
         }
 
+        private void OnDestroy()
+        {
+            if (_backingElement != null)
+            {
+                _backingElement.OnElementChanged -= Draw;
+            }
+        }
+
         public override void Draw()
         {
             base.Draw();

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
@@ -36,6 +36,8 @@ namespace BoneLib.BoneMenu.UI
         {
             base.Draw();
             _nameText.text = _backingElement.ElementName;
+            _nameText.color = _backingElement.ElementColor;
+
             _valueText.text = _backingElement.Value.ToString();
         }
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
@@ -29,6 +29,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(EnumElement element)
         {
             _backingElement = element;
+            element.OnElementChanged += Draw;
         }
 
         public override void Draw()

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIEnumElement.cs
@@ -29,20 +29,26 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(EnumElement element)
         {
             _backingElement = element;
-            element.OnElementChanged += Draw;
+            element.OnElementChanged += Refresh;
         }
 
         private void OnDestroy()
         {
             if (_backingElement != null)
             {
-                _backingElement.OnElementChanged -= Draw;
+                _backingElement.OnElementChanged -= Refresh;
             }
         }
 
         public override void Draw()
         {
             base.Draw();
+
+            Refresh();
+        }
+
+        public void Refresh()
+        {
             _nameText.text = _backingElement.ElementName;
             _nameText.color = _backingElement.ElementColor;
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
@@ -36,6 +36,14 @@ namespace BoneLib.BoneMenu.UI
             element.OnElementChanged += Draw;
         }
 
+        private void OnDestroy()
+        {
+            if (_backingElement != null)
+            {
+                _backingElement.OnElementChanged -= Draw;
+            }
+        }
+
         public override void Draw()
         {
             base.Draw();

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
@@ -33,14 +33,14 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(FloatElement element)
         {
             _backingElement = element;
-            element.OnElementChanged += Draw;
+            element.OnElementChanged += Refresh;
         }
 
         private void OnDestroy()
         {
             if (_backingElement != null)
             {
-                _backingElement.OnElementChanged -= Draw;
+                _backingElement.OnElementChanged -= Refresh;
             }
         }
 
@@ -48,6 +48,11 @@ namespace BoneLib.BoneMenu.UI
         {
             base.Draw();
 
+            Refresh();
+        }
+
+        public void Refresh()
+        {
             _nameText.text = _backingElement.ElementName;
             _nameText.color = _backingElement.ElementColor;
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
@@ -33,6 +33,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(FloatElement element)
         {
             _backingElement = element;
+            element.OnElementChanged += Draw;
         }
 
         public override void Draw()

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFloatElement.cs
@@ -41,6 +41,8 @@ namespace BoneLib.BoneMenu.UI
             base.Draw();
 
             _nameText.text = _backingElement.ElementName;
+            _nameText.color = _backingElement.ElementColor;
+
             _valueText.text = _backingElement.Value.ToString();
         }
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
@@ -33,6 +33,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(FunctionElement element)
         {
             _backingElement = element;
+            element.OnElementChanged += Draw;
         }
 
         public override void OnPressed()

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
@@ -33,14 +33,14 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(FunctionElement element)
         {
             _backingElement = element;
-            element.OnElementChanged += Draw;
+            element.OnElementChanged += Refresh;
         }
 
         private void OnDestroy()
         {
             if (_backingElement != null)
             {
-                _backingElement.OnElementChanged -= Draw;
+                _backingElement.OnElementChanged -= Refresh;
             }
         }
 
@@ -58,8 +58,13 @@ namespace BoneLib.BoneMenu.UI
         {
             base.Draw();
 
+            Refresh();
+        }
+
+        public void Refresh()
+        {
             _backline.SetActive(!_backingElement.Properties.HasFlag(ElementProperties.NoBorder));
-            
+
             if (_nameText == null)
             {
                 return;

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
@@ -36,6 +36,14 @@ namespace BoneLib.BoneMenu.UI
             element.OnElementChanged += Draw;
         }
 
+        private void OnDestroy()
+        {
+            if (_backingElement != null)
+            {
+                _backingElement.OnElementChanged -= Draw;
+            }
+        }
+
         public override void OnPressed()
         {
             if (_backingElement == null)

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIFunctionElement.cs
@@ -58,6 +58,8 @@ namespace BoneLib.BoneMenu.UI
             }
 
             _nameText.text = _backingElement.ElementName;
+            _nameText.color = _backingElement.ElementColor;
+
             _logo.texture = _backingElement.Logo;
 
             _nameText.gameObject.SetActive(_logo.texture == null);

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
@@ -37,6 +37,14 @@ namespace BoneLib.BoneMenu.UI
             element.OnElementChanged += Draw;
         }
 
+        private void OnDestroy()
+        {
+            if (_backingElement != null)
+            {
+                _backingElement.OnElementChanged -= Draw;
+            }
+        }
+
         public override void Draw()
         {
             base.Draw();

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
@@ -42,6 +42,8 @@ namespace BoneLib.BoneMenu.UI
             base.Draw();
 
             _nameText.text = _backingElement.ElementName;
+            _nameText.color = _backingElement.ElementColor;
+
             _valueText.text = _backingElement.Value.ToString();
         }
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
@@ -34,6 +34,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(IntElement element)
         {
             _backingElement = element;
+            element.OnElementChanged += Draw;
         }
 
         public override void Draw()

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIIntElement.cs
@@ -34,14 +34,14 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(IntElement element)
         {
             _backingElement = element;
-            element.OnElementChanged += Draw;
+            element.OnElementChanged += Refresh;
         }
 
         private void OnDestroy()
         {
             if (_backingElement != null)
             {
-                _backingElement.OnElementChanged -= Draw;
+                _backingElement.OnElementChanged -= Refresh;
             }
         }
 
@@ -49,6 +49,11 @@ namespace BoneLib.BoneMenu.UI
         {
             base.Draw();
 
+            Refresh();
+        }
+
+        public void Refresh()
+        {
             _nameText.text = _backingElement.ElementName;
             _nameText.color = _backingElement.ElementColor;
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
@@ -33,6 +33,14 @@ namespace BoneLib.BoneMenu.UI
             element.OnElementChanged += Draw;
         }
 
+        private void OnDestroy()
+        {
+            if (_backingElement != null)
+            {
+                _backingElement.OnElementChanged -= Draw;
+            }
+        }
+
         public override void Draw()
         {
             base.Draw();

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
@@ -38,6 +38,8 @@ namespace BoneLib.BoneMenu.UI
             base.Draw();
 
             _nameText.text = _backingElement.ElementName;
+            _nameText.color = _backingElement.ElementColor;
+
             _inputField.text = _backingElement.Value;
         }
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
@@ -30,14 +30,14 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(StringElement element)
         {
             _backingElement = element;
-            element.OnElementChanged += Draw;
+            element.OnElementChanged += Refresh;
         }
 
         private void OnDestroy()
         {
             if (_backingElement != null)
             {
-                _backingElement.OnElementChanged -= Draw;
+                _backingElement.OnElementChanged -= Refresh;
             }
         }
 
@@ -45,6 +45,11 @@ namespace BoneLib.BoneMenu.UI
         {
             base.Draw();
 
+            Refresh();
+        }
+
+        public void Refresh()
+        {
             _nameText.text = _backingElement.ElementName;
             _nameText.color = _backingElement.ElementColor;
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/GUIStringElement.cs
@@ -30,6 +30,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(StringElement element)
         {
             _backingElement = element;
+            element.OnElementChanged += Draw;
         }
 
         public override void Draw()
@@ -43,7 +44,7 @@ namespace BoneLib.BoneMenu.UI
         private void OnInputFieldSubmit(string input)
         {
             _inputField.text = input;
-            _backingElement.SetText(input);
+            _backingElement.Value = input;
             Draw();
         }
 

--- a/BoneLib/BoneLib/BoneMenu/UI/Keyboard/Keyboard.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Keyboard/Keyboard.cs
@@ -61,7 +61,7 @@ namespace BoneLib.BoneMenu.UI
                 throw new NullReferenceException("Connected element is not connected, or is null!");
             }
 
-            _connectedElement.SetText(_inputField.text);
+            _connectedElement.Value = _inputField.text;
             _connectedElement.OnElementSelected();
             _connectedGUIElement.Draw();
         }


### PR DESCRIPTION
Adds a few basic quality of life features to the new menu, as well as some missing features from the old menu.

### Added:
* Setters for Page Name and Color
* Setters for Element Name, Color, Value, and Tooltip
* PageLinkElement
     * Inherits from FunctionElement, contains a variable representing its Page. This is so that it can track updates to the page as well as its removal.

### Fixed:
* Element colors not being applied to the element text
* Page destruction not being implemented (Menu.DestroyPage)
     * This should clear all page values, but I recommend checking it to see if I missed anything

### Improved:
* Variable added to CreatePage to automatically create a link. Defaults to true.
     * This allows people to create pages without having to worry about links, but can choose to create a manual link if they need.

Tested with Fusion's BoneMenu implementation, haven't noticed any issues yet.