### PR TITLE
Fixed System.Windows.Forms not using the BONELAB_DIR variable

### DIFF
--- a/BoneLib/BoneLib/BoneLib.csproj
+++ b/BoneLib/BoneLib/BoneLib.csproj
@@ -43,7 +43,7 @@
       <HintPath>$(BONELAB_DIR)\MelonLoader\net6\Il2CppInterop.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows.Forms">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\BONELAB\MelonLoader\Managed\System.Windows.Forms.dll</HintPath>
+      <HintPath>$(BONELAB_DIR)\MelonLoader\Managed\System.Windows.Forms.dll</HintPath>
     </Reference>
     <Reference Include="UniTask">
       <HintPath>$(BONELAB_DIR)\MelonLoader\Il2CppAssemblies\Il2CppUniTask.dll</HintPath>


### PR DESCRIPTION
The dependency to System.Windows.Forms didnt use the variable, so if you tried to build BoneLib but your game path was in another folder, it wouldn't be able to build.